### PR TITLE
Treat all lists as required

### DIFF
--- a/License.hs
+++ b/License.hs
@@ -73,9 +73,9 @@ data OSILicense = OSILicense {
   , olName :: Text
   , olSuperseded_by :: Maybe Text
   , olKeywords :: [Text]
-  , olIdentifiers :: Maybe [OSIIdentifier]  -- BUG in API response?
+  , olIdentifiers :: [OSIIdentifier]
   , olLinks :: [OSILink]
-  , olOther_names :: Maybe [OSIOtherName]   -- BUG in API response?
+  , olOther_names :: [OSIOtherName]
   , olText :: [OSIText]
 } deriving (Eq, Read, Show)
 $(deriveJSON defaultOptions{fieldLabelModifier = (map toLower . drop 2), constructorTagModifier = map toLower} ''OSILicense)


### PR DESCRIPTION
Now that the web service is fixed[0] we don't need to
use Maybe for any lists.

[0] https://github.com/OpenSourceOrg/licenses/pull/32
